### PR TITLE
feat: add support for custom border colors

### DIFF
--- a/src/components/preview/ImageFlow.vue
+++ b/src/components/preview/ImageFlow.vue
@@ -66,8 +66,8 @@ const height = computed(() => stagePages.value.length * 1080);
                 <KonvaAvatar
                   :member="action.actor"
                   :side="148"
-                  stroke="black"
-                  :stroke-width="2"
+                  :stroke="action.borderColor ?? 'black'"
+                  :stroke-width="4"
                   :x="(index % 4) * 150 + 10 * (index % 4) + 1"
                   :y="Math.floor(index / 4) * 160 + 1"
                 />

--- a/src/components/preview/Stage.vue
+++ b/src/components/preview/Stage.vue
@@ -37,7 +37,7 @@ const hover = useElementHover(container);
     </Inplace>
     <div class="stage-avatars-container">
       <template v-for="action in stage.actions">
-        <StudentAvatar :member="action.actor" class="border-4 w-[150px] border-black" />
+        <StudentAvatar :member="action.actor" class="border-4 w-[150px]" :style="{ borderColor: action.borderColor }" />
       </template>
     </div>
     <div class="stage-control" :class="[hover ? 'opacity-100' : 'opacity-0']">

--- a/src/utils/generatePages.ts
+++ b/src/utils/generatePages.ts
@@ -1,7 +1,10 @@
 export type StageInfo = {
   comment: string | undefined;
   commentWidth: number;
-  actions: Array<{ actor: Member }>;
+  actions: Array<{
+    actor: Member;
+    borderColor?: string;
+  }>;
   y: number;
   avatarsY: number;
 };
@@ -40,7 +43,7 @@ export function calculateStagePages(teams: ReturnType<Team["toObject"]>[], gap: 
       const data = {
         comment: stage.comment,
         commentWidth: metrics.comment.width,
-        actions: stage.actions.map(({ actor }) => ({ actor })),
+        actions: stage.actions.map(({ actor, borderColor }) => ({ actor, borderColor })),
         y,
         avatarsY: metrics.comment.height + 20,
       };

--- a/src/utils/parseTextToStages.ts
+++ b/src/utils/parseTextToStages.ts
@@ -1,4 +1,4 @@
-const pattern = /(?<student1>[^\s()#]+)(?<colorCode>#[0-9a-fA-F]{6})?(\((?<comment>[^()]+)\))?/;
+const pattern = /(?<student1>[^\s()@]+)(?:@(?<colorCode>[0-9a-fA-F]{6}|[a-zA-Z]+))?(?:\((?<comment>[^()]+)\))?/;
 
 export function joinComment(commentA: string | undefined, commentB: string | undefined): string {
   return [commentA, commentB].filter(Boolean).join("，");
@@ -26,7 +26,10 @@ export function parseTextToStages(text: string, studentMap: StudentMap): Array<S
       if (match?.groups) {
         const { student1, colorCode, comment } = match.groups;
         const actor = searchStudentByNameMap.get(student1)?.id;
-        if (actor) actions.push({ actor, borderColor: colorCode??"#000000" });
+        const borderColor = colorCode
+          ? (/^[0-9a-fA-F]{6}$/.test(colorCode) ? `#${colorCode}` : colorCode)
+          : "#000000";
+        if (actor) actions.push({ actor, borderColor });
         else comments.push(student1);
         if (comment) comments.push(comment);
       } else {

--- a/src/utils/parseTextToStages.ts
+++ b/src/utils/parseTextToStages.ts
@@ -1,4 +1,4 @@
-const pattern = /(?<student1>[^\s()]+)(\((?<comment>[^()]+)\))?/;
+const pattern = /(?<student1>[^\s()#]+)(?<colorCode>#[0-9a-fA-F]{6})?(\((?<comment>[^()]+)\))?/;
 
 export function joinComment(commentA: string | undefined, commentB: string | undefined): string {
   return [commentA, commentB].filter(Boolean).join("，");
@@ -24,9 +24,9 @@ export function parseTextToStages(text: string, studentMap: StudentMap): Array<S
     stageText.split("+").forEach((action) => {
       const match = action.match(pattern);
       if (match?.groups) {
-        const { student1, comment } = match.groups;
+        const { student1, colorCode, comment } = match.groups;
         const actor = searchStudentByNameMap.get(student1)?.id;
-        if (actor) actions.push({ actor });
+        if (actor) actions.push({ actor, borderColor: colorCode??"#000000" });
         else comments.push(student1);
         if (comment) comments.push(comment);
       } else {

--- a/src/utils/type.d.ts
+++ b/src/utils/type.d.ts
@@ -1,6 +1,6 @@
 export { };
 declare global {
-  type Action = { actor: Member; target?: Member };
+  type Action = { actor: Member; target?: Member ; borderColor?: string};
   type Stage = { actions: Action[]; comment?: string };
   type StudentId = number;
   type StudentMap = Map<StudentId, Student>;

--- a/src/utils/type.d.ts
+++ b/src/utils/type.d.ts
@@ -1,6 +1,6 @@
 export { };
 declare global {
-  type Action = { actor: Member; target?: Member ; borderColor?: string};
+  type Action = { actor: Member; target?: Member; borderColor?: string };
   type Stage = { actions: Action[]; comment?: string };
   type StudentId = number;
   type StudentMap = Map<StudentId, Student>;


### PR DESCRIPTION
Increase generated image border width to make border colors more visible.

Sample input:
```
羽留奈#0000FF+亞瑠#FF0000(test) → 亞瑠(test2) 
```
Note that previously it is allowed to use `#` in student's nick name, but that will not be allowed after this changes