### PR TITLE
fix: When color code is not supported, fall back to black color

### DIFF
--- a/src/utils/parseTextToStages.ts
+++ b/src/utils/parseTextToStages.ts
@@ -26,9 +26,10 @@ export function parseTextToStages(text: string, studentMap: StudentMap): Array<S
       if (match?.groups) {
         const { student1, colorCode, comment } = match.groups;
         const actor = searchStudentByNameMap.get(student1)?.id;
-        const borderColor = colorCode
-          ? (/^[0-9a-fA-F]{6}$/.test(colorCode) ? `#${colorCode}` : colorCode)
-          : "#000000";
+        const borderColor = (CSS.supports('color', colorCode)) ? colorCode
+            : (/^[0-9a-fA-F]{6}$/.test(colorCode)) ? `#${colorCode}`
+            : "#000000";
+
         if (actor) actions.push({ actor, borderColor });
         else comments.push(student1);
         if (comment) comments.push(comment);


### PR DESCRIPTION
When an unsupported color code was used, the border previously kept its old color until the tab was reloaded.
This update adds a fallback to black, making invalid color codes immediately visible and keeping the output stable.